### PR TITLE
remove obsolete dnssec directive

### DIFF
--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -28,7 +28,6 @@ options {
 <%- end -%>
 	auth-nxdomain <%= @auth_nxdomain ? 'yes' : 'no' %>;
 	listen-on-v6 { any; };
-	dnssec-enable <%= @dnssec ? 'yes' : 'no' %>;
 <%- if @filter_ipv6 -%>
 	filter-aaaa-on-v4 yes;
 <%- end -%>


### PR DESCRIPTION
This was crashing bind 9.18 on Debian bookworm completely:

nov 23 13:47:02 curie named[2252420]: /etc/bind/named.conf:12: option 'dnssec-enable' no longer exists