### PR TITLE
default recursion to false

### DIFF
--- a/manifests/view.pp
+++ b/manifests/view.pp
@@ -5,7 +5,7 @@ define bind::view (
     $match_destinations           = '',
     $servers                      = {},
     $zones                        = [],
-    $recursion                    = true,
+    $recursion                    = false,
     $recursion_match_clients      = 'any',
     $recursion_match_destinations = '',
     $recursion_match_only         = false,


### PR DESCRIPTION
Recursion on an authoritative nameserver is a security risk. See for example:

https://www.iana.org/help/nameserver-requirements